### PR TITLE
Homepage logo

### DIFF
--- a/docs/components/Logo.vue
+++ b/docs/components/Logo.vue
@@ -1,0 +1,3 @@
+<template>
+	<img src="/volverjs.svg" />
+</template>

--- a/docs/contents/home/index.md
+++ b/docs/contents/home/index.md
@@ -1,7 +1,7 @@
 <header>
     <div class="flex flex-col mx-auto px-16 py-xl relative">
         <div class="flex flex-col flex-1 justify-center items-center text-center mb-xl">
-            <img src="/volverjs.svg" alt="Volver" class="w-208 md:w-256 h-auto" width="256" height="256" />
+            <Logo alt="Volver" class="w-208 md:w-256 h-auto" width="256" height="256"></Logo>
             <h1 class="vv-text vv-text--headline text-48 tracking-tighter md:text-60 font-black my-md">
                 The Easy Way to Style
             </h1>
@@ -99,7 +99,7 @@
                   params: { name: 'customization' },
                   hash: '#zero-specificity',
                   }" class="vv-button vv-button--rounded vv-button--full-bleed">
-                  Learn more
+                  Learn more about specificity
               </router-link>
         </div>
     </section>
@@ -135,7 +135,7 @@
                   params: { name: 'customization' },
                   hash: '#css-custom-properties',
                   }" class="vv-button vv-button--rounded vv-button--full-bleed">
-                  Learn more
+                  Customize your style
               </router-link>
         </div>
     </section>
@@ -165,7 +165,7 @@
               params: { name: 'customization' },
               hash: '#components',
             }" class="vv-button vv-button--rounded vv-button--full-bleed">
-            Learn more
+            Make your own components
           </router-link>
         </div>
     </section>

--- a/docs/pages/index.vue
+++ b/docs/pages/index.vue
@@ -3,6 +3,7 @@
 	import CodeEditor from '../components/CodeEditor.vue'
 	import FooterNotes from '../components/FooterNotes.vue'
 	import CopyCode from '../components/CopyCode.vue'
+	import Logo from '../components/Logo.vue'
 	import { VueComponentWith } from '../contents/home/index.md'
 
 	useHead({
@@ -17,6 +18,7 @@
 	})
 
 	const MainContent = VueComponentWith({
+		Logo,
 		CodeEditor,
 		FooterNotes,
 		RouterLink,

--- a/src/_preflight.scss
+++ b/src/_preflight.scss
@@ -90,6 +90,10 @@
 			@extend %font-mono !optional;
 		}
 
+		&:where(p > code) {
+			@extend %whitespace-nowrap !optional;
+		}
+
 		&:where(sub) {
 			@extend %align-sub !optional;
 			@extend %text-smaller !optional;

--- a/src/settings/components/_vv-text.scss
+++ b/src/settings/components/_vv-text.scss
@@ -2,7 +2,6 @@ $vv-text: (
 	font-family: var(--font-sans),
 	font-weight: var(--font-normal),
 	line-height: var(--leading-normal),
-	text-wrap: balance,
 	modifier: (
 		headline: (
 			font-weight: var(--font-semibold),


### PR DESCRIPTION
fix: Homepage logo (`vite-plugin-markdow` relative path bug)
fix: `vv-text` experimental `text-wrap: balance`
feat: preflight `code` inside `p` without wrap