### PR TITLE
feat: raise the dropdown layer and support top-layer popovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+* `popover` and `popover-open` states in the BEM generator: a component map can now style an element promoted to the top layer through the Popover API. They compile to `[popover]` and `:popover-open` alongside the usual `--state` and `.state` selectors.
+* `vv-dropdown` neutralizes the user agent styles applied to `[popover]` elements (`inset`, `margin`, `padding`, `border`, `overflow`, `background`, `color`), so a dropdown promoted to the top layer keeps the coordinates set by its positioning library instead of being centered in the viewport.
+
+### Changed
+* **`--z-dropdown` moved from `1000` to `1025`**, above `--z-sticky` (`1010`) and `--z-fixed` (`1020`). A dropdown anchored to a fixed header or to a sticky toolbar has to cover it, and it was the only floating layer sitting below the app chrome: `--z-popover` (`1070`) and `--z-tooltip` (`1080`) were already above it. Layouts that relied on a dropdown being painted under a fixed header need to raise that element instead.
+
 ## [0.1.24] - 2026-06-15
 
 ### Added

--- a/docs/contents/utilities/layout/z-index.md
+++ b/docs/contents/utilities/layout/z-index.md
@@ -7,9 +7,9 @@ description: Utilities for controlling the stack order of an element.
 	<card-example>
 		<div class="relative container rounded-md bg-surface-1 p-24">
 			<div class="absolute inset-0 bg-grid mix-blend-plus-lighter"></div>
-			<div class="relative h-80 mx-auto w-11/12 bg-brand-lighten-5 z-dropdown"></div>
-			<div class="relative h-80 nt-40 mx-auto w-10/12 bg-brand-lighten-4 z-sticky"></div>
-			<div class="relative h-80 nt-40 mx-auto w-9/12 bg-brand-lighten-3 z-fixed"></div>
+			<div class="relative h-80 mx-auto w-11/12 bg-brand-lighten-5 z-sticky"></div>
+			<div class="relative h-80 nt-40 mx-auto w-10/12 bg-brand-lighten-4 z-fixed"></div>
+			<div class="relative h-80 nt-40 mx-auto w-9/12 bg-brand-lighten-3 z-dropdown"></div>
 			<div class="relative h-80 nt-40 mx-auto w-8/12 bg-brand-lighten-2 z-modal-backdrop"></div>
 			<div class="relative h-80 nt-40 mx-auto w-7/12 bg-brand-lighten-1 z-modal"></div>
 			<div class="relative h-80 nt-40 mx-auto w-6/12 bg-brand z-confirm-backdrop"></div>

--- a/src/settings/_layout.scss
+++ b/src/settings/_layout.scss
@@ -113,11 +113,13 @@ $visibility: (
 ) !default;
 
 // z-index
+// Floating layers (dropdown, popover, tooltip) sit above the app chrome
+// (sticky, fixed): a menu anchored to a fixed header has to cover it.
 $z-index: (
 	1: 1,
-	dropdown: 1000,
 	sticky: 1010,
 	fixed: 1020,
+	dropdown: 1025,
 	modal-backdrop: 1030,
 	modal: 1040,
 	confirm-backdrop: 1050,

--- a/src/settings/components/_vv-dropdown.scss
+++ b/src/settings/components/_vv-dropdown.scss
@@ -7,6 +7,20 @@ $vv-dropdown: (
 	flex-direction: column,
 	box-shadow: var(--shadow-lg),
 	width: max-content,
+	state: (
+		// Neutralize the user agent styles applied to [popover] elements, so a
+		// dropdown promoted to the top layer keeps the coordinates it gets from
+		// its positioning library instead of being centered in the viewport
+		popover: (
+			inset: auto,
+			margin: 0,
+			padding: 0,
+			border: 0,
+			overflow: visible,
+			background: transparent,
+			color: inherit,
+		),
+	),
 	element: (
 		list: (
 			_alias: 'div:is([role="menu"],[role="list-box"])',

--- a/src/tools/mixin-modules/_bem.scss
+++ b/src/tools/mixin-modules/_bem.scss
@@ -23,6 +23,29 @@ $-valid-states: (
 	popover, popover-open
 );
 
+// Selector suffixes appended to the block, and to its alias when there is one,
+// for the states that are not plain pseudo-classes. A state can need more than
+// one suffix: "disabled" also matches the aria attribute. States missing here
+// fall back to ":not([disabled]):<state>", while "current" adds no suffix at
+// all and keeps only the BEM selectors built by the caller.
+$-state-suffixes: (
+	checked: ':checked',
+	checked-within: ':has(input:checked)',
+	close: ':not([open])',
+	dirty: ':not(:has(*:placeholder-shown))',
+	disabled: ('[disabled]', '[aria-disabled="true"]'),
+	focus-visible: ':not(:active):not([disabled]):not([tabindex="-1"]):not([aria-disabled="true"]):focus-visible',
+	multiple: '[multiple]',
+	open: '[open]',
+	// Element promoted to the top layer through the Popover API: "popover"
+	// matches it whether it is open or not, "popover-open" only when it is
+	popover: '[popover]',
+	popover-open: ':popover-open',
+	pressed: '[aria-pressed="true"]',
+	readonly: '[readonly]',
+	selected: '[aria-selected="true"]',
+);
+
 // ============================================
 // Main BEM mixin
 // ============================================
@@ -495,93 +518,17 @@ $-valid-states: (
 // Helper to add state-specific selectors
 // Returns the updated selectors list
 @function -add-state-selectors($state, $block-item, $modifier, $alias, $selectors) {
-	@if $state == 'checked-within' {
-		$selectors: list.join($selectors, '#{$modifier}#{$block-item}:has(input:checked)');
+	@if $state == 'current' {
+		@return $selectors;
+	}
+
+	$suffixes: map.get($-state-suffixes, $state) or ':not([disabled]):#{$state}';
+
+	@each $suffix in $suffixes {
+		$selectors: list.join($selectors, '#{$modifier}#{$block-item}#{$suffix}');
 
 		@if $alias {
-			$selectors: list.join($selectors, '#{$modifier}#{$alias}:has(input:checked)');
-		}
-	} @else if $state == 'open' {
-		$selectors: list.join($selectors, '#{$modifier}#{$block-item}[open]');
-
-		@if $alias {
-			$selectors: list.join($selectors, '#{$modifier}#{$alias}[open]');
-		}
-	} @else if $state == 'close' {
-		$selectors: list.join($selectors, '#{$modifier}#{$block-item}:not([open])');
-
-		@if $alias {
-			$selectors: list.join($selectors, '#{$modifier}#{$alias}:not([open])');
-		}
-	} @else if $state == 'popover' {
-		// Element promoted to the top layer through the Popover API: the rules
-		// apply whether the popover is open or not
-		$selectors: list.join($selectors, '#{$modifier}#{$block-item}[popover]');
-
-		@if $alias {
-			$selectors: list.join($selectors, '#{$modifier}#{$alias}[popover]');
-		}
-	} @else if $state == 'popover-open' {
-		$selectors: list.join($selectors, '#{$modifier}#{$block-item}:popover-open');
-
-		@if $alias {
-			$selectors: list.join($selectors, '#{$modifier}#{$alias}:popover-open');
-		}
-	} @else if $state == 'dirty' {
-		$selectors: list.join($selectors, '#{$modifier}#{$block-item}:not(:has(*:placeholder-shown))');
-
-		@if $alias {
-			$selectors: list.join($selectors, '#{$modifier}#{$alias}:not(:has(*:placeholder-shown))');
-		}
-	} @else if $state == 'disabled' or $state == 'readonly' or $state == 'multiple' {
-		$selectors: list.join($selectors, '#{$modifier}#{$block-item}[#{$state}]');
-
-		@if $alias {
-			$selectors: list.join($selectors, '#{$modifier}#{$alias}[#{$state}]');
-		}
-
-		@if $state == 'disabled' {
-			$selectors: list.join($selectors, '#{$modifier}#{$block-item}[aria-disabled="true"]');
-
-			@if $alias {
-				$selectors: list.join($selectors, '#{$modifier}#{$alias}[aria-disabled="true"]');
-			}
-		}
-	} @else if $state == 'focus-visible' {
-		$selectors: list.join(
-			$selectors,
-			'#{$modifier}#{$block-item}:not(:active):not([disabled]):not([tabindex="-1"]):not([aria-disabled="true"]):#{$state}'
-		);
-
-		@if $alias {
-			$selectors: list.join(
-				$selectors,
-				'#{$modifier}#{$alias}:not(:active):not([disabled]):not([tabindex="-1"]):not([aria-disabled="true"]):#{$state}'
-			);
-		}
-	} @else if $state == 'checked' {
-		$selectors: list.join($selectors, '#{$modifier}#{$block-item}:#{$state}');
-
-		@if $alias {
-			$selectors: list.join($selectors, '#{$modifier}#{$alias}:#{$state}');
-		}
-	} @else if $state == 'pressed' {
-		$selectors: list.join($selectors, '#{$modifier}#{$block-item}[aria-pressed="true"]');
-
-		@if $alias {
-			$selectors: list.join($selectors, '#{$modifier}#{$alias}[aria-pressed="true"]');
-		}
-	} @else if $state == 'selected' {
-		$selectors: list.join($selectors, '#{$modifier}#{$block-item}[aria-selected="true"]');
-
-		@if $alias {
-			$selectors: list.join($selectors, '#{$modifier}#{$alias}[aria-selected="true"]');
-		}
-	} @else if $state != 'current' {
-		$selectors: list.join($selectors, '#{$modifier}#{$block-item}:not([disabled]):#{$state}');
-
-		@if $alias {
-			$selectors: list.join($selectors, '#{$modifier}#{$alias}:not([disabled]):#{$state}');
+			$selectors: list.join($selectors, '#{$modifier}#{$alias}#{$suffix}');
 		}
 	}
 

--- a/src/tools/mixin-modules/_bem.scss
+++ b/src/tools/mixin-modules/_bem.scss
@@ -19,7 +19,8 @@ $-valid-states: (
 	active, focus, hover, focus-within, target, visited, focus-visible,
 	disabled, checked, checked-within, multiple, selected, readonly,
 	empty, placeholder-shown, dirty, valid, invalid, indeterminate,
-	first-child, last-child, open, close, determinate, pressed, current
+	first-child, last-child, open, close, determinate, pressed, current,
+	popover, popover-open
 );
 
 // ============================================
@@ -511,6 +512,20 @@ $-valid-states: (
 
 		@if $alias {
 			$selectors: list.join($selectors, '#{$modifier}#{$alias}:not([open])');
+		}
+	} @else if $state == 'popover' {
+		// Element promoted to the top layer through the Popover API: the rules
+		// apply whether the popover is open or not
+		$selectors: list.join($selectors, '#{$modifier}#{$block-item}[popover]');
+
+		@if $alias {
+			$selectors: list.join($selectors, '#{$modifier}#{$alias}[popover]');
+		}
+	} @else if $state == 'popover-open' {
+		$selectors: list.join($selectors, '#{$modifier}#{$block-item}:popover-open');
+
+		@if $alias {
+			$selectors: list.join($selectors, '#{$modifier}#{$alias}:popover-open');
 		}
 	} @else if $state == 'dirty' {
 		$selectors: list.join($selectors, '#{$modifier}#{$block-item}:not(:has(*:placeholder-shown))');


### PR DESCRIPTION
## Why

`--z-dropdown` was the lowest floating layer at `1000`, below `--z-sticky` (`1010`) and `--z-fixed` (`1020`), while `--z-popover` (`1070`) and `--z-tooltip` (`1080`) already sat above the app chrome. A dropdown anchored to a fixed header or to a sticky toolbar was therefore painted under it, and the only way out was raising the whole panel that hosts the dropdown.

Stacking order alone cannot rescue a dropdown that is trapped in an ancestor stacking context: `position: fixed` takes an element out of the flow, not out of the context. The Popover API can, by promoting the element to the top layer, and this is the CSS side of that change (the component side is `volverjs/ui-vue`, `feature/dropdown-top-layer`).

## What

- `--z-dropdown` moves from `1000` to `1025`, between `--z-fixed` and `--z-modal-backdrop`.
- New `popover` and `popover-open` states in the BEM generator: they compile to `[popover]` and `:popover-open` alongside the usual `--state` and `.state` selectors, so any component map can style an element that lives in the top layer.
- `vv-dropdown` uses the first one to neutralize the user agent styles applied to `[popover]` elements (`inset`, `margin`, `padding`, `border`, `overflow`, `background`, `color`). Without it the user agent `inset: 0` and `margin: auto` center the promoted dropdown in the viewport, ignoring the coordinates set by the positioning library.
- The utilities documentation page listed the layers in ascending order and has been reordered accordingly.

## Refactor

`-add-state-selectors` repeated the same shape in every branch: append a suffix to the block, then to its alias when there is one. The suffixes now live in a map with a single loop over them, so 83 lines become 30 and a new state is one entry instead of a branch. `disabled` keeps both of its suffixes because the map accepts a list.

## Verification

- `pnpm build`, `pnpm stylelint` and `pnpm stylelint:dist` pass.
- The refactor was checked against the previous build: `components.css`, `utilities.css`, `props.css` and `volver.css` are byte identical.
- The new state compiles to `:where(.vv-dropdown--popover,.vv-dropdown.popover,.vv-dropdown[popover])`.

## Breaking

Layouts that relied on a dropdown being painted below a fixed header now need to raise that element instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Popover API support for BEM-generated state selectors, including `[popover]` and `:popover-open`.
  * Added dropdown styling resets to preserve positioning when popovers enter the top layer.

* **Bug Fixes**
  * Raised the dropdown stacking level above sticky and fixed layers to improve overlay visibility.
  * Updated z-index examples to reflect the correct stacking order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->