### PR TITLE
fix(ci): install with a frozen lockfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,9 @@ jobs:
               run: pnpm stylelint:dist
 
             # `pnpm version` refuses to run on an unclean working tree, and the
-            # tree is expected to be unclean at this point: the install can
-            # refresh the lockfile and the build regenerates design-tokens.json.
-            # `npm pkg set` only rewrites the field, with no git checks.
+            # tree is expected to be unclean at this point: the build regenerates
+            # design-tokens.json, which is a tracked file. `npm pkg set` only
+            # rewrites the field, with no git checks.
             - name: Bump version with release tag name
               if: github.event_name == 'release'
               env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,13 @@ jobs:
                   node-version: 24
                   cache: 'pnpm'
 
+            # Keep the lockfile frozen: with `--no-frozen-lockfile` a pull
+            # request that changes package.json alone still went green, the
+            # install silently resolved the new ranges and rewrote the lockfile
+            # in the job. Every dependency bump landed on develop with a stale
+            # lockfile, and the release build broke on it.
             - name: Install dependencies
-              run: pnpm install --no-frozen-lockfile
+              run: pnpm install --frozen-lockfile
 
             - name: Build release
               run: pnpm build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,11 @@ jobs:
             # install silently resolved the new ranges and rewrote the lockfile
             # in the job. Every dependency bump landed on develop with a stale
             # lockfile, and the release build broke on it.
+            #
+            # No `--ignore-scripts` on purpose: pnpm already refuses to run the
+            # scripts of any dependency that is not listed under `allowBuilds`
+            # in pnpm-workspace.yaml, and the four packages listed there need
+            # their build step.
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Why

`build.yml` installed with `--no-frozen-lockfile`, which is the reason the v0.1.25 release build failed and the reason nobody noticed earlier.

A depfu pull request changes `package.json` and leaves `pnpm-lock.yaml` untouched. With the lockfile unfrozen the check installed happily, resolving the new ranges and rewriting the lockfile inside the job, so the pull request went green and `pr-depfu-merge.yml` automerged it. Three of them landed on develop that way (#97, #100, #101), each leaving the committed lockfile behind. The bill arrived at release time: the same install rewrote the lockfile during the release job, and `pnpm version` refused to run on the resulting unclean working tree.

## What

`pnpm install --frozen-lockfile` in the shared build workflow, which the PR check suite and the release both call. The check now fails on the pull request that introduces the gap, and since `trigger-automerge` needs `build`, a depfu pull request can no longer be automerged until its lockfile is updated.

## Trade off

Depfu pull requests that ship only `package.json` will sit with a red check until the lockfile is regenerated (`pnpm install`, commit). That is the intended outcome: a red pull request is visible and cheap to fix, a stale lockfile on develop is neither. Worth looking at whether depfu can be configured to update the pnpm lockfile itself, which would remove the manual step.

## SonarCloud

Touching the install line made it new code, which surfaced `githubactions:S6505`, "omitting --ignore-scripts allows lifecycle scripts to run during package installation". The flag is deliberately not added: pnpm refuses to run the scripts of any dependency that is not listed under `allowBuilds` in `pnpm-workspace.yaml`, so the mitigation the rule asks for is already in place, while `--ignore-scripts` would also skip the build step of the four packages listed there (`esbuild`, `@parcel/watcher`, `core-js`, `vue-inbrowser-compiler-demi`). The issue is marked as accepted and the reasoning is recorded in the workflow comment.

## Verification

`pnpm install --frozen-lockfile` passes on the current develop, since volverjs/style#102 aligned the lockfile with all three bumps. Without that alignment this change would fail, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build process to use the locked dependency versions consistently.
  * Added documentation clarifying dependency installation requirements and addressing stale lockfile issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
