### PR TITLE
Release of v0.1.27

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,117 @@
+# AGENTS.md
+
+Notes for agents working on `@volverjs/style`, the SCSS design system that produces the CSS
+consumed by `@volverjs/ui-vue` and by static pages.
+
+## What this repository is
+
+The source of truth is SCSS under `src/`, and the deliverable is the compiled CSS under
+`dist/`. Nothing in `dist/` is edited by hand.
+
+| Path | What lives there |
+| --- | --- |
+| `src/settings/components/` | One configuration map per component (`$vv-button`, `$vv-input-text`, ...). This is where a component's look is declared. |
+| `src/tools/mixin-modules/_bem.scss` | The BEM generator: it walks those maps and emits blocks, elements, modifiers, states, breakpoints and transitions. |
+| `src/tools/mixin-modules/_theme.scss` | The same walk for the dark theme, without `@extend`. |
+| `src/components/` | One entry per component, which calls the generator with its map. |
+| `src/props/`, `src/settings/` | Design tokens and the global settings the maps read. |
+| `src/utilities/`, `src/base.scss`, `src/_preflight.scss` | Utility classes, base layer and reset. |
+| `docs/` | Source of the documentation site. `npm run styleguide` builds it with Vite SSG into `styleguide/`, which is generated and git ignored. |
+
+A component map is a nested structure of `element`, `modifier`, `state`, `pseudo`,
+`breakpoint` and `transition` keys. Two keys are not CSS and drive the generator instead:
+`_alias` gives an element a second selector for plain markup (`_alias: '> small'` next to
+`.vv-select__hint`), and `_combinator` scopes it. An `_alias` must be a single selector, never
+a comma separated list.
+
+## Definition of done
+
+Run all of these before reporting a change as finished, and report a skipped one as skipped.
+
+```bash
+npm run stylelint      # stylelint over src/**/*.scss
+npm run lint           # eslint over the repository
+npm run build          # compiles dist/ and regenerates design-tokens.json
+npm run stylelint:dist # stylelint over the compiled dist/**/*.css
+```
+
+There are no unit tests. Correctness is established by compiling and reading the emitted CSS,
+so the two checks below carry the weight tests would carry elsewhere.
+
+### The compiled output is the test
+
+Snapshot `dist/` before touching anything, rebuild, and diff:
+
+```bash
+cp -R dist /tmp/dist-before
+npm run build
+diff -r /tmp/dist-before dist
+```
+
+Say in the changelog which of the two outcomes you got and why:
+
+- **Identical byte for byte.** Expected for a refactor, and for a fix to a branch that no
+  component map reaches yet. This is the strongest evidence a change is safe.
+- **Changed.** Then every changed rule is intentional and accounted for. Read the diff rule by
+  rule, do not skim it.
+
+`npm run build` also rewrites `design-tokens.json` and the `exports` map in `package.json`.
+Both are tracked, and both should come back unchanged unless tokens or entry points actually
+moved.
+
+### Probe a branch the library does not reach
+
+Much of the generator is only exercised by shapes no component map uses today. Do not conclude
+such a branch is fine because `dist/` did not move: compile a synthetic map that walks straight
+into it, and read the selectors it emits.
+
+```bash
+cat > /tmp/probe.scss <<'EOF'
+@use 'src/context' as *;
+
+$m: (/* the shape under test */);
+
+@include spread-map-into-bem($map: $m, $block: 'vv-probe', $bps: $breakpoints);
+EOF
+
+node -e "
+const sass = require('sass-embedded');
+console.log(sass.compile('/tmp/probe.scss', { loadPaths: ['.'] }).css);
+"
+```
+
+Pass `$bps: $breakpoints`, otherwise the breakpoint branches compile to nothing and the probe
+silently proves less than it looks. Run the probe with and without the change, and diff the two
+outputs: that is what tells you which rules moved.
+
+## Things that have bitten before
+
+- **A selector list is not a selector.** The generator passes selectors around as strings glued
+  with commas. Suffixing or compounding one of those as a whole reaches its last entry alone
+  and leaves the ones before it bare. Walk the list, or send it through `list-to-string`, which
+  is how the rest of the generator emits one.
+- **`list.append` on a single value gives a space separated list.** A list of one has no
+  separator, so Sass falls back to a space, and the result interpolates to a descendant
+  selector instead of two alternatives.
+- **`@for $i from 1 through 0` counts down.** It runs the body with an index that reaches past
+  an empty list rather than skipping it.
+- **The empty string is truthy in Sass.** `@if $modifier` is true for the `''` default, so test
+  `$modifier != ''` when the difference matters.
+- **Assignment reaches the enclosing scope.** Reusing a variable name inside a nested loop or a
+  recursive mixin writes to the outer one. The generator relies on this on purpose in places
+  and has been broken by it in others.
+- **A `var()` inside a custom property is substituted where that property is declared**, not
+  where it is read. A declaration that has to follow a token written further down the tree
+  (`--input-range-progress`, `--direction`) is emitted as a plain declaration, wrapped in
+  `[brackets]` in the map, instead of going through the generated `--vv-*` property.
+
+## Conventions
+
+- Write everything that lands in the repository in English: commits, comments, changelog.
+- Prose carries no em dashes or en dashes.
+- Every fix gets a `CHANGELOG.md` entry under the release it ships in, written as prose that
+  explains the mechanism and the consequence, not as a one line summary. Match the surrounding
+  entries.
+- `version` in `package.json` stays `0.0.0` and is set at publish time. The changelog heading
+  is what names a release.
+- Commit only when asked, and group the work into coherent commits rather than one per edit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.27] - 2026-09-08
+## [0.1.27] - 2026-09-09
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.27] - 2026-09-08
+
+### Fixed
+
+* Three places in the BEM generator suffixed a selector list as if it were a single selector. A list glued with commas reaches its last entry alone: the suffix lands there, and every entry before it stays in the rule bare, matching more than it was meant to or nothing at all. Each of them now walks the list and suffixes one entry at a time.
+
+  `spread-map-into-control-states` appended the `_alias` of an element to its BEM selector with `list.append`, and a list of one has no separator, so Sass fell back to a space and the two compiled to a descendant selector instead of two alternatives: the `:has()` rule for a state on an aliased element came out as `.vv-input-text:has(input[disabled]) .vv-input-text__input .vv-input-text:has(input[disabled]) input`, four levels deep and matching nothing, and its `state` and `pseudo` variants inherited the same chain. The override the rule carried was dropped rather than applied. The three selectors now pass through `list-to-string`, the way the rest of the generator emits a selector list.
+
+  `spread-map-into-states` interpolated the alias whole while it walked the block selectors one by one. Under a state of the block, where the parent expands to four selectors, the alias arrives as four selectors too, so `.vv-select__option, select > option.checked` put the state on the last one and left the others as unconditional element selectors, repeated once per block selector. Block and alias are built side by side by `spread-map-into-elements`, one entry per selector of the parent, so they are now walked by index and each alias is paired with the block selector it was nested under.
+
+  `spread-map-into-breakpoints` compounded the block onto the modifier as `#{$modifier}#{$block}`. A modifier is a single selector, but a state and a transition hand down their whole selector list, so `state.<name>.breakpoint` scoped only its last entry to the block and `transition.<name>.active.breakpoint` only its second. The two are now compounded pair by pair.
+
+  No component map in the library reaches any of the three branches, so `volver.scss` and the dark theme compile identical byte for byte: every element carrying a `state` or `pseudo` map under a state of the block is one without an alias, and the only `breakpoint` maps sit under a modifier or under an element, where the modifier is empty or a single selector.
+
 ## [0.1.26] - 2026-09-07
 
 ### Added

--- a/src/tools/mixin-modules/_bem.scss
+++ b/src/tools/mixin-modules/_bem.scss
@@ -322,6 +322,10 @@ $-state-suffixes: (
 
 	@if meta.type-of(map.get($map, $key)) == 'map' {
 		@each $element, $value in map.get($map, $key) {
+			// `$block` is the block selector alone, threaded down unchanged
+			// from `spread-map-into-bem`: what a state or a transition
+			// expands to travels in `$modifier` instead. Passing a selector
+			// list here would suffix its last entry alone.
 			$selector: $block + '__' + $element;
 
 			// combinator
@@ -354,6 +358,10 @@ $-state-suffixes: (
 
 			@if $alias {
 				@if $modifier {
+					// One entry per selector of the modifier, in the same
+					// order as `$selector` above: `spread-map-into-states`
+					// pairs the two lists by index, so an `_alias` has to be
+					// a single selector, not a list of them.
 					$aliases: ();
 
 					@each $item in selector.parse($modifier) {
@@ -442,15 +450,35 @@ $-state-suffixes: (
 		@each $state, $value in map.get($map, $key) {
 			@if list.index($-valid-states, $state) {
 				$selectors: ();
+				$block-items: selector.parse($block);
+				$alias-items: ();
 
-				@each $block-item in selector.parse($block) {
+				// `$block` and `$alias` are built side by side by the caller,
+				// one entry per selector of the parent, so they are walked by
+				// index: the alias belongs to the block item it was nested
+				// under. Suffixing the list as a whole would reach its last
+				// entry alone and leave the ones before it in the rule bare.
+				@if $alias {
+					$alias-items: selector.parse($alias);
+				}
+
+				$i: 0;
+
+				@each $block-item in $block-items {
+					$i: $i + 1;
+					$alias-item: null;
+
+					@if $i <= list.length($alias-items) {
+						$alias-item: list.nth($alias-items, $i);
+					}
+
 					$selectors: list.join(
 						$selectors,
 						('#{$modifier}#{$block-item}--#{$state}', '#{$modifier}#{$block-item}.#{$state}')
 					);
 
-					@if $alias {
-						$selectors: list.join($selectors, '#{$modifier}#{$alias}.#{$state}');
+					@if $alias-item {
+						$selectors: list.join($selectors, '#{$modifier}#{$alias-item}.#{$state}');
 					}
 
 					// Special state handling - use function to get updated selectors
@@ -458,7 +486,7 @@ $-state-suffixes: (
 						$state: $state,
 						$block-item: $block-item,
 						$modifier: $modifier,
-						$alias: $alias,
+						$alias: $alias-item,
 						$selectors: $selectors
 					);
 				}
@@ -558,6 +586,27 @@ $-state-suffixes: (
 		$block: &;
 	}
 
+	// A state and a transition hand their whole selector list down as the
+	// modifier, so the block is compounded onto each of its entries: written
+	// as one interpolation it would reach the last entry alone and leave the
+	// ones before it in the rule unscoped.
+	$selector: '#{$modifier}#{$block}';
+
+	@if $modifier and $modifier != '' and $block {
+		$selectors: ();
+
+		@each $modifier-item in selector.parse($modifier) {
+			@each $block-item in selector.parse($block) {
+				$selectors: list.join(
+					$selectors,
+					'#{$modifier-item}#{$block-item}'
+				);
+			}
+		}
+
+		$selector: list-to-string($selectors);
+	}
+
 	@if meta.type-of(map.get($map, $key)) == 'map' {
 		@each $breakpoint, $value in map.get($map, $key) {
 			@if string.index($breakpoint, '-') {
@@ -566,7 +615,7 @@ $-state-suffixes: (
 
 				@if map.has-key($bps, $bp) {
 					@if $operator == 'up' {
-						@include wrap-with-where($selector: '#{$modifier}#{$block}', $enabled: $zero-specificity) {
+						@include wrap-with-where($selector: $selector, $enabled: $zero-specificity) {
 							@include media-breakpoint-up($bp, $bps) {
 								@include spread-map-into-attrs(
 									$original: $original,
@@ -581,7 +630,7 @@ $-state-suffixes: (
 					}
 
 					@if $operator == 'down' {
-						@include wrap-with-where($selector: '#{$modifier}#{$block}', $enabled: $zero-specificity) {
+						@include wrap-with-where($selector: $selector, $enabled: $zero-specificity) {
 							@include media-breakpoint-down($bp, $bps) {
 								@include spread-map-into-attrs(
 									$original: $original,
@@ -596,7 +645,7 @@ $-state-suffixes: (
 					}
 
 					@if map.has-key($bps, $operator) {
-						@include wrap-with-where($selector: '#{$modifier}#{$block}', $enabled: $zero-specificity) {
+						@include wrap-with-where($selector: $selector, $enabled: $zero-specificity) {
 							@include media-breakpoint-between($operator, $bp, $bps) {
 								@include spread-map-into-attrs(
 									$original: $original,
@@ -611,7 +660,7 @@ $-state-suffixes: (
 					}
 				}
 			} @else if map.has-key($bps, $breakpoint) {
-				@include wrap-with-where($selector: '#{$modifier}#{$block}', $enabled: $zero-specificity) {
+				@include wrap-with-where($selector: $selector, $enabled: $zero-specificity) {
 					@include media-breakpoint-up($breakpoint, $bps) {
 						@include spread-map-into-attrs(
 							$original: $original,
@@ -765,6 +814,11 @@ $-state-suffixes: (
 				);
 				$alias: map.get($map, 'element', $element, '_alias');
 
+				// The alias is a second selector for the same element, not a
+				// descendant of the first, so the list is glued with a comma
+				// before it is emitted: interpolating it would join the two
+				// with a space and compile them to one selector that matches
+				// a `.vv-input-text` nested inside its own element.
 				@if $alias {
 					$element-selector: list.append(
 						$element-selector,
@@ -773,7 +827,7 @@ $-state-suffixes: (
 				}
 
 				@include wrap-with-where(
-					$selector: $element-selector,
+					$selector: list-to-string($element-selector),
 					$enabled: $zero-specificity
 				) {
 					@extend %#{$block}-state-#{$state}__#{$element} !optional;
@@ -794,7 +848,7 @@ $-state-suffixes: (
 						}
 
 						@include wrap-with-where(
-							$selector: $element-selector-state,
+							$selector: list-to-string($element-selector-state),
 							$enabled: $zero-specificity
 						) {
 							@extend %#{$block}-state-#{$state}-element-#{$element}--#{$element-state}
@@ -816,7 +870,7 @@ $-state-suffixes: (
 						}
 
 						@include wrap-with-where(
-							$selector: $element-selector-pseudo,
+							$selector: list-to-string($element-selector-pseudo),
 							$enabled: $zero-specificity
 						) {
 							@extend %#{$block}-state-#{$state}-element-#{$element}--#{$pseudo}


### PR DESCRIPTION
First release since v0.1.26, and a small one: it fixes three latent defects in the BEM generator and writes down how this repository is meant to be worked on. No component map reaches any of the three branches today, so the compiled CSS does not move.

### Fixed

* **Three places in the BEM generator suffixed a selector list as if it were a single selector.** Selectors travel through the generator as strings glued with commas, and a comma separated string reaches its last entry alone: the suffix lands there, and every entry before it stays in the rule bare, matching more than it was meant to or nothing at all. Each of them now walks the list.

  `spread-map-into-control-states` appended the `_alias` of an element to its BEM selector with `list.append`, and a list of one has no separator, so Sass fell back to a space and the two compiled to a descendant selector instead of two alternatives: the `:has()` rule for a state on an aliased element came out four levels deep and matched nothing, and its `state` and `pseudo` variants inherited the same chain. The override the rule carried was dropped rather than applied.

  `spread-map-into-states` interpolated the alias whole while it walked the block selectors one by one. Under a state of the block, where the parent expands to four selectors, the alias arrives as four too, so the state landed on the last one and left the others as unconditional element selectors, repeated once per block selector.

  `spread-map-into-breakpoints` compounded the block onto the modifier as one interpolation. A modifier is a single selector, but a state and a transition hand down their whole list, so `state.<name>.breakpoint` scoped only its last entry to the block and `transition.<name>.active.breakpoint` only its second.

### Added

* `AGENTS.md`, because the definition of done lived only in the scripts of `package.json` and the two practices that stand in for tests in this repository lived nowhere at all: the `dist` snapshot diff, with how to read each of its two outcomes, and the synthetic probe for the branches no component map reaches, with the `$bps: $breakpoints` trap that makes a probe prove less than it appears to. It also records the six traps that have already cost time here.

### Why the compiled output does not change

Every element carrying a `state` or `pseudo` map under a state of the block is one without an alias, and the only `breakpoint` maps sit under a modifier or under an element, where the modifier is empty or a single selector. Verified by walking all thirty two component maps, and confirmed by the build: `volver.scss` and the dark theme compile identical byte for byte.

The three are latent, not theoretical. Each would surface the moment a component put a state override on the element it aliases, which is the ordinary way to dim a disabled control.

Since `dist` cannot move, the branches were exercised with a synthetic map covering the nesting matrix: block, state, modifier, nested modifier and transition, each with an aliased element carrying `state`, `pseudo` and `breakpoint`. Twenty five rules come out, three of them changed, and they are the three that were broken.

### Nothing to do for consumers

No generated custom property is added or removed, no selector changes, no token moves. Upgrading from v0.1.26 changes nothing in the CSS you ship.

---

After the merge, push the `v0.1.27` tag on `main` to let `release-tag.yml` create the release, which triggers the build and the npm publish. The published version comes from the tag name, so `package.json` stays at `0.0.0` in git.
